### PR TITLE
Add PutReaderChunked

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,4 +1,0 @@
-# Please keep the list sorted.
-
-Arif Mahmud Rana <arif@furqansoftware.com>
-Mahmud Ridwan <ridwan@furqansoftware.com>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Improved Go package for disk-based blob cache.
 
 Install Stash using the go get command:
 
-    $ go get https://github.com/RstorLabs/stash.v1.1.0 
+    $ go get github.com/RstorLabs/stash
 
 The only dependency is the Go distribution.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stash
 
-A Go package for disk-based blob cache.
+Improved Go package for disk-based blob cache.
 
 ![](https://github.com/go-stash/stash/raw/master/folder.png)
 
@@ -8,17 +8,13 @@ A Go package for disk-based blob cache.
 
 Install Stash using the go get command:
 
-    $ go get gopkg.in/stash.v1
+    $ go get https://github.com/RstorLabs/stash.v1.1.0 
 
 The only dependency is the Go distribution.
 
 ## Motivation
 
 This package allows us to reduce calls to our blob storage by caching the most recently used blobs to disk.
-
-## Documentation
-
-- [Reference](https://godoc.org/gopkg.in/stash.v1)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stash
 
-Improved Go package for disk-based blob cache.
+Improved Go package for disk-based blob cache for files and chunks of files.
 
 ![](https://github.com/go-stash/stash/raw/master/folder.png)
 

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,388 @@
+package stash
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+)
+
+type FileEntry struct {
+	Offset    map[int64]struct{}
+	CommonTag []byte
+	wg        sync.WaitGroup
+}
+
+type ChunkCache struct {
+	Cache  Cache
+	Chunks map[string]*FileEntry
+	L      sync.Mutex
+}
+
+func NewChunkCache(dir string, sz, c int64) (*ChunkCache, error) {
+	cache, err := NewCache(dir, sz, c)
+	if err != nil {
+		return nil, err
+	}
+	return &ChunkCache{
+		Chunks: make(map[string]*FileEntry),
+		Cache:  *cache,
+	}, nil
+}
+
+func (c *ChunkCache) GetTag(key string, offset int64) ([]byte, error) {
+
+	c.L.Lock()
+	defer c.L.Unlock()
+
+	elem := c.Chunks[key]
+	if elem == nil {
+		return nil, ErrNotFound
+	}
+
+	tag, err := c.Cache.GetTag(mkey(key, offset))
+	if err != nil {
+		delete(elem.Offset, offset)
+		if len(elem.Offset) == 0 {
+			delete(c.Chunks, key)
+		}
+		return nil, ErrChunkNotFound
+	}
+
+	return tag, nil
+}
+
+func (c *ChunkCache) GetCommonTag(key string) ([]byte, error) {
+	c.L.Lock()
+	defer c.L.Unlock()
+
+	elem := c.Chunks[key]
+	if elem == nil {
+		return nil, ErrNotFound
+	}
+	return elem.CommonTag, nil
+}
+
+func (c *ChunkCache) SetTag(key string, offset int64, tag []byte) error {
+	c.L.Lock()
+	defer c.L.Unlock()
+	return c.unlockedSetTag(key, offset, tag)
+}
+
+func (c *ChunkCache) unlockedSetTag(key string, offset int64, tag []byte) error {
+
+	var err error
+	var ptag []byte
+
+	elem := c.Chunks[key]
+	if elem == nil {
+		return ErrNotFound
+	}
+	if _, ok := elem.Offset[offset]; !ok {
+		return ErrChunkNotFound
+	}
+
+	keyfile := mkey(key, offset)
+
+	ptag, err = c.Cache.GetTag(keyfile)
+	if err != nil {
+		delete(elem.Offset, offset)
+		if len(elem.Offset) == 0 {
+			delete(c.Chunks, key)
+		}
+		return err
+	}
+
+	switch {
+	case ptag == nil:
+		if err := c.Cache.SetTag(keyfile, tag); err != nil {
+			return err
+		}
+	case !bytes.Equal(ptag, tag):
+		return ErrAlreadyTagged
+	}
+
+	// keyfile is tagged with tag!
+	//
+
+	if tag != nil {
+		elem.CommonTag = tag
+	}
+
+	// dismiss the unsafe entries, that is entries untagged or tagged with a different tag.
+
+	for off, _ := range elem.Offset {
+		if off != offset {
+			res, err := c.Cache.DeleteIf(mkey(key, off), func(t []byte) bool {
+				return !bytes.Equal(t, tag)
+			})
+			if res && err == nil {
+				delete(elem.Offset, off)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *ChunkCache) SetUntaggedChunks(key string, tag []byte) (int, error) {
+
+	var err error
+	var ptag []byte
+	tagged := 0
+
+	c.L.Lock()
+	defer c.L.Unlock()
+
+	elem := c.Chunks[key]
+	if elem == nil {
+		return 0, ErrNotFound
+	}
+
+	if elem.CommonTag != nil && !bytes.Equal(elem.CommonTag, tag) {
+		return 0, ErrIncoherentTag
+	}
+
+	// set all untagged chunks with the given tag
+	//
+
+	for offset, _ := range elem.Offset {
+
+		keyfile := mkey(key, offset)
+		ptag, err = c.Cache.GetTag(keyfile)
+		if err != nil {
+			delete(elem.Offset, offset)
+			if len(elem.Offset) == 0 {
+				delete(c.Chunks, key)
+			}
+			continue
+		}
+
+		switch {
+		case ptag == nil:
+			if err := c.Cache.SetTag(keyfile, tag); err != nil {
+				panic(err)
+			}
+			tagged++
+		case !bytes.Equal(ptag, tag):
+			panic("Tag mismatch with commonTag")
+		}
+	}
+
+	if tag != nil {
+		elem.CommonTag = tag
+	}
+	return tagged, nil
+}
+
+func (c *ChunkCache) Clear() error {
+
+	c.L.Lock()
+	defer c.L.Unlock()
+
+	err := c.Cache.Clear()
+
+	if err == nil {
+		c.Chunks = make(map[string]*FileEntry)
+	}
+	return err
+}
+
+func (c *ChunkCache) Put(key string, offset int64, val []byte) error {
+	return c.PutWithTag(key, offset, nil, val)
+}
+
+func (c *ChunkCache) PutWithTag(key string, offset int64, tag []byte, val []byte) error {
+
+	c.L.Lock()
+	file := c.getFileEntry(key)
+	c.L.Unlock()
+
+	file.wg.Add(1)
+	defer file.wg.Done()
+
+	err := c.Cache.PutWithTag(mkey(key, offset), tag, val)
+	if err != nil {
+		return err
+	}
+	c.L.Lock()
+	defer c.L.Unlock()
+	c.addChunkOffset(key, offset)
+	if tag == nil {
+		return nil
+	}
+	return c.unlockedSetTag(key, offset, tag)
+}
+
+func (c *ChunkCache) PutReader(key string, offset int64, r LazyReader) (io.ReadCloser, error) {
+	return c.PutReaderWithTag(key, offset, nil, r)
+}
+
+func (c *ChunkCache) PutReaderWithTag(key string, offset int64, tag []byte, lz LazyReader) (io.ReadCloser, error) {
+
+	c.L.Lock()
+	file := c.getFileEntry(key)
+	c.L.Unlock()
+
+	file.wg.Add(1)
+	defer file.wg.Done()
+
+	r, err := c.Cache.PutReaderWithTag(mkey(key, offset), tag, lz)
+	if err != nil {
+		return r, err
+	}
+	c.L.Lock()
+	defer c.L.Unlock()
+	c.addChunkOffset(key, offset)
+	if tag == nil {
+		return r, nil
+	}
+	return r, c.unlockedSetTag(key, offset, tag)
+}
+
+func (c *ChunkCache) WaitPut(key string) {
+	c.L.Lock()
+	file := c.getFileEntry(key)
+	c.L.Unlock()
+
+	file.wg.Wait()
+}
+
+func (c *ChunkCache) Get(key string, offset int64) (ReadSeekCloser, int64, error) {
+	rd, tag, size, err := c.GetWithTag(key, offset)
+	if tag == nil {
+		return rd, 0, ErrUntagged
+	}
+	return rd, size, err
+}
+
+func (c *ChunkCache) GetWithTag(key string, offset int64) (ReadSeekCloser, []byte, int64, error) {
+	rd, tag, size, err := c.Cache.GetWithTag(mkey(key, offset))
+	if err != nil {
+		c.L.Lock()
+		defer c.L.Unlock()
+		c.delChunkOffset(key, offset)
+	}
+	return rd, tag, size, err
+}
+
+func (c *ChunkCache) Delete(key string) error {
+	c.L.Lock()
+	defer c.L.Unlock()
+	var err error
+	if elem, ok := c.Chunks[key]; ok {
+		for offset, _ := range elem.Offset {
+			if e := c.unlockedDeleteChunk(key, offset); e != nil {
+				err = e
+			}
+		}
+	} else {
+		return ErrNotFound
+	}
+	return err
+}
+
+func (c *ChunkCache) DeleteChunk(key string, offset int64) error {
+	c.L.Lock()
+	defer c.L.Unlock()
+	return c.unlockedDeleteChunk(key, offset)
+}
+
+func (c *ChunkCache) unlockedDeleteChunk(key string, offset int64) error {
+	if c.delChunkOffset(key, offset) {
+		return c.Cache.Delete(mkey(key, offset))
+	}
+	return ErrChunkNotFound
+}
+
+func (c *ChunkCache) GetStats() Stats {
+	return c.Cache.GetStats()
+}
+
+func (c *ChunkCache) ResetStats() {
+	c.Cache.ResetStats()
+}
+
+func (c *ChunkCache) Empty() bool {
+	return c.Cache.Empty()
+}
+
+func (c *ChunkCache) Shrink() {
+	c.L.Lock()
+	defer c.L.Unlock()
+	for key, elem := range c.Chunks {
+		for offset, _ := range elem.Offset {
+			_, err := c.Cache.GetTag(mkey(key, offset))
+			if err != nil {
+				delete(elem.Offset, offset)
+			}
+		}
+		if len(elem.Offset) == 0 {
+			delete(c.Chunks, key)
+		}
+	}
+}
+
+func (c *ChunkCache) NumEntries() int64 {
+	return int64(len(c.Chunks))
+}
+
+func (c *ChunkCache) NumChunksOf(key string) (int64, error) {
+	c.L.Lock()
+	defer c.L.Unlock()
+
+	elem := c.Chunks[key]
+	if elem == nil {
+		return 0, ErrNotFound
+	}
+
+	return int64(len(elem.Offset)), nil
+}
+
+func (c *ChunkCache) NumTotalChunks() int64 {
+	return c.Cache.NumEntries()
+}
+
+func (c *ChunkCache) Size() int64 {
+	return c.Cache.Size()
+}
+
+func (c *ChunkCache) Keys() []string {
+	return c.Cache.Keys()
+}
+
+////////////////////////////////////////////////////////////////
+
+func mkey(key string, offset int64) string {
+	return fmt.Sprintf("%s#%d", key, offset)
+}
+
+func (c *ChunkCache) getFileEntry(key string) *FileEntry {
+	if elem := c.Chunks[key]; elem != nil {
+		return elem
+	}
+	elem := FileEntry{
+		Offset: make(map[int64]struct{}),
+	}
+	c.Chunks[key] = &elem
+	return &elem
+}
+
+func (c *ChunkCache) addChunkOffset(key string, offset int64) {
+	elem := c.getFileEntry(key)
+	elem.Offset[offset] = struct{}{}
+}
+
+func (c *ChunkCache) delChunkOffset(key string, offset int64) bool {
+
+	if elem, ok := c.Chunks[key]; ok {
+		if _, ok := elem.Offset[offset]; ok {
+			delete(elem.Offset, offset)
+			if len(elem.Offset) == 0 {
+				delete(c.Chunks, key)
+			}
+			return true
+		}
+	}
+
+	return false
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,514 @@
+package stash
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestGetUntagged(t *testing.T) {
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+	_, _, err = s.Get("test", 0)
+	if err != ErrUntagged {
+		t.Fatalf("Expected error == ErrUntagged, got error '%s'", err)
+	}
+}
+
+func TestGet(t *testing.T) {
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+	err = s.SetTag("test", 0, []byte("TAG"))
+	catch(err)
+	_, _, err = s.Get("test", 0)
+	catch(err)
+}
+
+func TestSetTag(t *testing.T) {
+
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+	err = s.SetTag("test", 0, []byte("TAG"))
+	catch(err)
+	err = s.SetTag("missing-file", 0, []byte("TAG2"))
+	if err != ErrNotFound {
+		t.Fatalf("Expected error == ErrNotFound, got error '%s'", err)
+	}
+	err = s.SetTag("test", 42, []byte("TAG"))
+	if err != ErrChunkNotFound {
+		t.Fatalf("Expected error == ErrChunkNotFound, got error '%s'", err)
+	}
+
+	tag, err := s.GetCommonTag("test")
+	catch(err)
+
+	if !bytes.Equal(tag, []byte("TAG")) {
+		t.Fatalf("Expected Commontag == 'tag', got error '%s'", tag)
+	}
+
+	err = s.SetTag("test", 0, []byte("TAG2"))
+	if err != ErrAlreadyTagged {
+		t.Fatalf("Expected error == ErrAlreadyTagged, got error '%s'", err)
+	}
+
+	// add another chunk with a valid tag...
+	//
+
+	err = s.Put("test", 42, []byte("content"))
+	catch(err)
+
+	if n, err := s.NumChunksOf("test"); err != nil || n != 2 {
+		t.Fatalf("Expected 2 chunks, got error '%s' numChunks = %d", err, n)
+	}
+
+	err = s.SetTag("test", 42, []byte("TAG"))
+	catch(err)
+
+	if ct, _ := s.GetCommonTag("test"); !bytes.Equal(ct, []byte("TAG")) {
+		t.Fatalf("Expected tag == 'tag'; got '%s'", ct)
+	}
+
+	if n, err := s.NumChunksOf("test"); err != nil || n != 2 {
+		t.Fatalf("Expected 2 chunks, got error '%s' numChunks = %d", err, n)
+	}
+
+	// add new chunks with different tag values.
+	//
+
+	err = s.Put("test", 100, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 150, []byte("content"))
+	catch(err)
+
+	err = s.SetTag("test", 100, []byte("NEW_TAG"))
+	catch(err)
+
+	if n, err := s.NumChunksOf("test"); err != nil || n != 1 {
+		t.Fatalf("Expected 1 chunk, got error '%s' numChunks = %d", err, n)
+	}
+
+	if n := s.NumEntries(); n != 1 {
+		t.Fatalf("Expected 1 underlining entry, got %d", n)
+	}
+
+	if ct, _ := s.GetCommonTag("test"); !bytes.Equal(ct, []byte("NEW_TAG")) {
+		t.Fatalf("Expected tag == NEW_TAG; got '%s'", ct)
+	}
+}
+
+func TestSetUntaggedChunks(t *testing.T) {
+
+	clearStorage()
+
+	var n int
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 10, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 20, []byte("content"))
+	catch(err)
+
+	n, err = s.SetUntaggedChunks("test", []byte("tag"))
+	catch(err)
+	if n != 3 {
+		t.Fatalf("expected return value == 3, got error %d", n)
+	}
+
+	// add additional chunks...
+
+	err = s.Put("test", 30, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 40, []byte("content"))
+	catch(err)
+
+	n, err = s.SetUntaggedChunks("test", []byte("tag"))
+	catch(err)
+	if n != 2 {
+		t.Fatalf("expected return value == 2, got error %d", n)
+	}
+
+	// add a new chunk with a new tag...
+
+	err = s.Put("test", 50, []byte("content"))
+	catch(err)
+
+	_, err = s.SetUntaggedChunks("test", []byte("new_tag"))
+	if err != ErrIncoherentTag {
+		t.Fatalf("expected errincoherenttag, got '%s'", err)
+	}
+
+	if ct, _ := s.GetCommonTag("test"); !bytes.Equal(ct, []byte("tag")) {
+		t.Fatalf("expected tag == _tag; got '%s'", ct)
+	}
+
+	if n, err := s.NumChunksOf("test"); err != nil || n != 6 {
+		t.Fatalf("expected 6 chunks, got error '%s' numchunks = %d", err, n)
+	}
+
+}
+
+func TestGets(t *testing.T) {
+
+	clearStorage()
+
+	var tag []byte
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 10, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 20, []byte("content"))
+	catch(err)
+
+	_, _, err = s.Get("test", 0)
+	if err != ErrUntagged {
+		t.Fatalf("Expected error ErrUntagged, got '%s'", err)
+	}
+
+	_, err = s.SetUntaggedChunks("test", []byte("tag"))
+	catch(err)
+
+	tag, err = s.GetCommonTag("test")
+	catch(err)
+
+	if !bytes.Equal(tag, []byte("tag")) {
+		t.Fatalf("expected tag == 'tag'; got '%s'", tag)
+	}
+
+	tag, err = s.GetTag("test", 0)
+	catch(err)
+	if !bytes.Equal(tag, []byte("tag")) {
+		t.Fatalf("expected tag == 'tag'; got '%s'", tag)
+	}
+	tag, err = s.GetTag("test", 10)
+	catch(err)
+	if !bytes.Equal(tag, []byte("tag")) {
+		t.Fatalf("expected tag == 'tag'; got '%s'", tag)
+	}
+	tag, err = s.GetTag("test", 20)
+	catch(err)
+	if !bytes.Equal(tag, []byte("tag")) {
+		t.Fatalf("expected tag == 'tag'; got '%s'", tag)
+	}
+}
+
+func TestGetTag(t *testing.T) {
+
+	clearStorage()
+
+	var tag []byte
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+
+	_, err = s.SetUntaggedChunks("test", []byte("tag"))
+	catch(err)
+
+	_, err = s.GetTag("unknown", 0)
+	if err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound; got '%s'", err)
+	}
+
+	_, err = s.GetTag("test", 10)
+	if err != ErrChunkNotFound {
+		t.Fatalf("expected ErrChunkNotFound; got '%s'", err)
+	}
+
+	tag, err = s.GetTag("test", 0)
+	if err != nil {
+		t.Fatalf("expected error; got '%s'", err)
+	}
+
+	if !bytes.Equal(tag, []byte("tag")) {
+		t.Fatalf("expected tag == 'tag'; got '%s'", tag)
+	}
+}
+
+func TestGetCommonTag(t *testing.T) {
+
+	clearStorage()
+
+	var tag []byte
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+
+	tag, err = s.GetCommonTag("test")
+	catch(err)
+
+	if tag != nil {
+		t.Fatalf("expected nil tag; got '%s'", tag)
+	}
+
+	_, err = s.SetUntaggedChunks("test", []byte("tag"))
+	catch(err)
+
+	tag, err = s.GetCommonTag("test")
+	catch(err)
+
+	if !bytes.Equal(tag, []byte("tag")) {
+		t.Fatalf("expected tag == 'tag'; got '%s'", tag)
+	}
+
+	_, err = s.GetCommonTag("unknown")
+	if err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound; got '%s'", err)
+	}
+}
+
+func TestChunkClear(t *testing.T) {
+
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.Put("test", 0, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 10, []byte("content"))
+	catch(err)
+
+	err = s.Put("test", 20, []byte("content"))
+	catch(err)
+
+	_, err = s.SetUntaggedChunks("test", []byte("tag"))
+	catch(err)
+
+	s.Clear()
+
+	if !s.Cache.Empty() {
+		t.Fatalf("stash expected to be empty!")
+	}
+
+	if !s.Empty() {
+		t.Fatalf("cache expected to be empty!")
+	}
+}
+
+func TestPutWithTag(t *testing.T) {
+
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.PutWithTag("test", 10, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.PutWithTag("test2", 0, []byte("tag2"), []byte("content"))
+	catch(err)
+
+	err = s.PutWithTag("test2", 10, []byte("tag2"), []byte("content"))
+	catch(err)
+
+	if n := s.NumEntries(); n != 2 {
+		t.Fatalf("Expected 2 entries, got %d", n)
+	}
+
+	if n := s.NumTotalChunks(); n != 4 {
+		t.Fatalf("Expected 4 total chunks, got %d", n)
+	}
+
+	err = s.PutWithTag("test", 100, []byte("xxx"), []byte("content"))
+	catch(err)
+
+	if n := s.NumEntries(); n != 2 {
+		t.Fatalf("Expected 2 entries, got %d", n)
+	}
+
+	if n := s.NumTotalChunks(); n != 3 {
+		t.Fatalf("Expected 3 total chunks, got %d", n)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.Delete("test")
+	if err != ErrNotFound {
+		t.Fatalf("Expected error ErrNotFound, got '%s'", err)
+	}
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.Delete("test")
+	catch(err)
+
+	if !s.Empty() {
+		t.Fatalf("Expected empty cache!")
+	}
+}
+
+func TestDeleteChunk(t *testing.T) {
+	clearStorage()
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.DeleteChunk("test", 10)
+	if err != ErrChunkNotFound {
+		t.Fatalf("Expected error ErrChunkNotFound, got '%s'", err)
+	}
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("content"))
+	catch(err)
+
+	err = s.DeleteChunk("test", 0)
+	catch(err)
+
+	if !s.Empty() {
+		t.Fatalf("Expected empty cache, size = %d, stash_size: %d", s.NumEntries(), s.Cache.NumEntries())
+	}
+}
+
+func TestStats(t *testing.T) {
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("1234"))
+	catch(err)
+
+	stats := s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{4, 1, 0, 0}) {
+		t.Fatalf("Expected Stats = [4, 1, 0, 0], got %v", res)
+	}
+
+	// overwriting the content when an entry is already in the cache with the same tag is a null operation.
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("12345678"))
+	catch(err)
+
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{4, 1, 0, 0}) {
+		t.Fatalf("Expected Stats = [4, 1, 0, 0], got %v", res)
+	}
+
+	err = s.PutWithTag("test", 10, []byte("tag"), []byte("1234"))
+	catch(err)
+
+	err = s.PutWithTag("test2", 0, []byte("tag"), []byte("1234"))
+	catch(err)
+
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{12, 3, 0, 0}) {
+		t.Fatalf("Expected Stats = [12, 3, 0, 0], got %v", res)
+	}
+
+	s.GetWithTag("test", 0)
+
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{12, 3, 1, 0}) {
+		t.Fatalf("Expected Stats = [12, 3, 1, 0], got %v", res)
+	}
+
+	s.GetWithTag("test", 10)
+
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{12, 3, 2, 0}) {
+		t.Fatalf("Expected Stats = [12, 3, 2, 0], got %v", res)
+	}
+
+	s.GetWithTag("test", 20)
+
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{12, 3, 2, 1}) {
+		t.Fatalf("Expected Stats = [12, 3, 2, 1], got %v", res)
+	}
+
+	s.GetWithTag("unknown", 20)
+
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{12, 3, 2, 2}) {
+		t.Fatalf("Expected Stats = [12, 3, 2, 2], got %v", res)
+	}
+
+	s.ResetStats()
+	stats = s.GetStats()
+	if res := []int64{stats.Size, stats.Entries, stats.Hit, stats.Miss}; !reflect.DeepEqual(res, []int64{12, 3, 0, 0}) {
+		t.Fatalf("Expected Stats = [12, 3, 0, 0], got %v", res)
+	}
+}
+
+func TestShrink(t *testing.T) {
+
+	s, err := NewChunkCache(storageDir, 2048000, 40)
+	catch(err)
+
+	err = s.PutWithTag("test", 0, []byte("tag"), []byte("1234"))
+	catch(err)
+
+	err = s.PutWithTag("test", 10, []byte("tag"), []byte("1234"))
+	catch(err)
+
+	err = s.PutWithTag("test", 20, []byte("tag"), []byte("1234"))
+	catch(err)
+
+	s.Cache.Clear()
+
+	nc, err := s.NumChunksOf("test")
+	catch(err)
+
+	if nc == s.NumTotalChunks() {
+		t.Fatalf("Expected number of chunks mismatch, got equal instead!")
+	}
+
+	s.Shrink()
+
+	nc, err = s.NumChunksOf("test")
+	if err != ErrNotFound {
+		t.Fatalf("Expected error == ErrNotFound, got error '%s'", err)
+	}
+
+	if nc != s.NumTotalChunks() {
+		t.Fatalf("Expected equal number of chunks, got different values: %d - %d!", nc, s.NumTotalChunks())
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -4,11 +4,9 @@ import "errors"
 
 var (
 	ErrNotFound = errors.New("not found")
-
-	ErrBadDir  = errors.New("invalid directory")
-	ErrBadSize = errors.New("storage size must be greater then zero")
-	ErrBadCap  = errors.New("file number must be greater then zero")
-
+	ErrBadDir   = errors.New("invalid directory")
+	ErrBadSize  = errors.New("storage size must be greater then zero")
+	ErrBadCap   = errors.New("file number must be greater then zero")
 	ErrTooLarge = errors.New("file size must be less or equal storage size")
 )
 

--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,8 @@ var (
 	ErrTooLarge      = errors.New("file size must be less or equal storage size")
 	ErrUntagged      = errors.New("file is not tagged")
 	ErrAlreadyTagged = errors.New("file is already tagged")
+	ErrChunkNotFound = errors.New("chunk not found")
+	ErrIncoherentTag = errors.New("incoherent tag")
 )
 
 // FileError records the storage directory name and key of the that failed to cached.

--- a/errors.go
+++ b/errors.go
@@ -3,11 +3,13 @@ package stash
 import "errors"
 
 var (
-	ErrNotFound = errors.New("not found")
-	ErrBadDir   = errors.New("invalid directory")
-	ErrBadSize  = errors.New("storage size must be greater then zero")
-	ErrBadCap   = errors.New("file number must be greater then zero")
-	ErrTooLarge = errors.New("file size must be less or equal storage size")
+	ErrNotFound      = errors.New("not found")
+	ErrBadDir        = errors.New("invalid directory")
+	ErrBadSize       = errors.New("storage size must be greater then zero")
+	ErrBadCap        = errors.New("file number must be greater then zero")
+	ErrTooLarge      = errors.New("file size must be less or equal storage size")
+	ErrUntagged      = errors.New("file is not tagged")
+	ErrAlreadyTagged = errors.New("file is already tagged")
 )
 
 // FileError records the storage directory name and key of the that failed to cached.

--- a/file.go
+++ b/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"sync"
 )
 
@@ -91,15 +92,11 @@ func writeFileValidate(c *Cache,
 	return path, total, nil
 }
 
-func filepath(dir, name string) string {
-	return dir + string(os.PathSeparator) + name
-}
-
 func shasum(v string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(v)))
 }
 
 func realFilePath(dir, key string) string {
 	name := shasum(key)
-	return filepath(dir, name)
+	return path.Join(dir, name)
 }

--- a/file.go
+++ b/file.go
@@ -53,7 +53,7 @@ func writeFileValidate(c *Cache,
 		}
 
 		total += int64(w)
-		if n <= chunkSize {
+		if n < chunkSize {
 			break
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -13,7 +13,8 @@ type exoBuffer struct {
 }
 
 const chunkSize = 4 * 1024 * 1024
-var s3FsPool = sync.Pool {
+
+var s3FsPool = sync.Pool{
 	New: func() interface{} {
 		return &exoBuffer{make([]byte, chunkSize)}
 	},

--- a/file.go
+++ b/file.go
@@ -47,7 +47,7 @@ func writeFileValidate(c *Cache,
 			return "", 0, &FileError{dir, key, err}
 		}
 
-		w, err := f.Write(buffer)
+		w, err := f.WriteAt(buffer, total)
 		if err != nil {
 			return "", 0, &FileError{dir, key, err}
 		}

--- a/file.go
+++ b/file.go
@@ -52,9 +52,12 @@ func writeFileValidate(c *Cache,
 
 	for {
 		// validate
+		c.l.Lock()
 		if err := c.validate(tmpPath, int64(chunkSize)); err != nil {
+			c.l.Unlock()
 			return tmpPath, 0, err
 		}
+		c.l.Unlock()
 
 		// copy
 		n, errRead := r.Read(exoBuf.bytes)

--- a/file.go
+++ b/file.go
@@ -50,7 +50,7 @@ func writeFileValidate(c *Cache,
 
 	for {
 		// validate
-		if err := c.validate(path, int64(chunkSize)); err != nil {
+		if err := c.validate(path, total + int64(chunkSize)); err != nil {
 			return path, 0, err
 		}
 

--- a/file.go
+++ b/file.go
@@ -58,11 +58,11 @@ func writeFileValidate(c *Cache,
 
 		// copy
 		n, errRead := r.Read(exoBuf.bytes)
-		if n <=0 && errRead != nil {
+		if n == 0 && errRead == io.EOF {
+			break
+		} else if n == 0 && errRead != nil {
 			_ = f.Close()
 			return tmpPath, 0, &FileError{dir, key, err}
-		} else if n == 0 && errRead != nil {
-			break
 		}
 
 		w, err := f.WriteAt(exoBuf.bytes[0:n], total)

--- a/file.go
+++ b/file.go
@@ -33,20 +33,26 @@ func writeFileValidate(c *Cache,
 		return "", 0, &FileError{dir, key, err}
 	}
 	var total int64
-	chunkSize := int64(1024)
+	chunkSize := 1024
+	buffer := make([]byte, 0, chunkSize)
 	for {
 		// validate
-		if err := c.validate(path, chunkSize); err != nil {
+		if err := c.validate(path, int64(chunkSize)); err != nil {
 			return path, 0, err
 		}
 
 		// copy
-		n, err := io.CopyN(f, r, 1024)
+		n, err := r.Read(buffer)
 		if err != nil {
 			return "", 0, &FileError{dir, key, err}
 		}
 
-		total += n
+		w, err := f.Write(buffer)
+		if err != nil {
+			return "", 0, &FileError{dir, key, err}
+		}
+
+		total += int64(w)
 		if n <= chunkSize {
 			break
 		}

--- a/file.go
+++ b/file.go
@@ -12,9 +12,10 @@ type exoBuffer struct {
 	bytes []byte
 }
 
-var s3FsPool = sync.Pool{
+const chunkSize = 4 * 1024 * 1024
+var s3FsPool = sync.Pool {
 	New: func() interface{} {
-		return &exoBuffer{make([]byte, 4*1024*1024)}
+		return &exoBuffer{make([]byte, chunkSize)}
 	},
 }
 
@@ -46,7 +47,6 @@ func writeFileValidate(c *Cache,
 		return "", 0, &FileError{dir, key, err}
 	}
 	var total int64
-	chunkSize := 1024 * 1024
 	exoBuf := s3FsPool.Get().(*exoBuffer)
 	defer s3FsPool.Put(exoBuf)
 

--- a/file.go
+++ b/file.go
@@ -97,6 +97,6 @@ func shasum(v string) string {
 }
 
 func realFilePath(dir, key string) string {
-	name := shasum(key)
+	name := shasum(key) + ".cache"
 	return path.Join(dir, name)
 }

--- a/file.go
+++ b/file.go
@@ -33,8 +33,8 @@ func writeFileValidate(c *Cache,
 		return "", 0, &FileError{dir, key, err}
 	}
 	var total int64
-	chunkSize := 1024
-	buffer := make([]byte, 0, chunkSize)
+	chunkSize := 1024 * 1024
+	buffer := make([]byte, chunkSize)
 	for {
 		// validate
 		if err := c.validate(path, int64(chunkSize)); err != nil {

--- a/file.go
+++ b/file.go
@@ -60,6 +60,8 @@ func writeFileValidate(c *Cache,
 		n, errRead := r.Read(exoBuf.bytes)
 		if n <=0 && errRead != nil {
 			return tmpPath, 0, &FileError{dir, key, err}
+		} else if n == 0 && errRead != nil {
+			break
 		}
 
 		w, err := f.WriteAt(exoBuf.bytes[0:n], total)
@@ -68,9 +70,6 @@ func writeFileValidate(c *Cache,
 		}
 
 		total += int64(w)
-		if n < chunkSize {
-			break
-		}
 	}
 	err = os.Rename(tmpPath, path)
 	if err != nil {

--- a/file.go
+++ b/file.go
@@ -57,8 +57,8 @@ func writeFileValidate(c *Cache,
 		}
 
 		// copy
-		n, err := r.Read(exoBuf.bytes)
-		if err != nil {
+		n, errRead := r.Read(exoBuf.bytes)
+		if n <=0 && errRead != nil {
 			return tmpPath, 0, &FileError{dir, key, err}
 		}
 

--- a/file.go
+++ b/file.go
@@ -9,9 +9,7 @@ import (
 
 // writeFile writes a new file to the cache storage.
 func writeFile(dir, key string, r io.Reader) (string, int64, error) {
-	name := shasum(key)
-	path := filepath(dir, name)
-
+	path := realFilePath(dir, key)
 	f, err := os.Create(path)
 	defer f.Close()
 	if err != nil {
@@ -25,10 +23,46 @@ func writeFile(dir, key string, r io.Reader) (string, int64, error) {
 	return path, n, nil
 }
 
+func writeFileValidate(c *Cache,
+	dir, key string, r io.Reader) (string, int64, error) {
+
+	path := realFilePath(dir, key)
+	f, err := os.Create(path)
+	defer f.Close()
+	if err != nil {
+		return "", 0, &FileError{dir, key, err}
+	}
+	var total int64
+	chunkSize := int64(1024)
+	for {
+		// validate
+		if err := c.validate(path, chunkSize); err != nil {
+			return path, 0, err
+		}
+
+		// copy
+		n, err := io.CopyN(f, r, 1024)
+		if err != nil {
+			return "", 0, &FileError{dir, key, err}
+		}
+
+		total += n
+		if n <= chunkSize {
+			break
+		}
+	}
+	return path, total, nil
+}
+
 func filepath(dir, name string) string {
 	return dir + string(os.PathSeparator) + name
 }
 
 func shasum(v string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(v)))
+}
+
+func realFilePath(dir, key string) string {
+	name := shasum(key)
+	return filepath(dir, name)
 }

--- a/file.go
+++ b/file.go
@@ -47,7 +47,7 @@ func writeFileValidate(c *Cache,
 			return "", 0, &FileError{dir, key, err}
 		}
 
-		w, err := f.WriteAt(buffer, total)
+		w, err := f.WriteAt(buffer[0:n], total)
 		if err != nil {
 			return "", 0, &FileError{dir, key, err}
 		}

--- a/file.go
+++ b/file.go
@@ -6,22 +6,9 @@ import (
 	"io"
 	"os"
 	"path"
-	"sync"
 
 	"github.com/gofrs/uuid"
 )
-
-type exoBuffer struct {
-	bytes []byte
-}
-
-const chunkSize = 4 * 1024 * 1024
-
-var s3FsPool = sync.Pool{
-	New: func() interface{} {
-		return &exoBuffer{make([]byte, chunkSize)}
-	},
-}
 
 // writeFile writes a new file to the cache storage.
 func writeTmpFile(dir, key string, r io.Reader) (string, int64, error) {
@@ -47,66 +34,12 @@ func writeTmpFile(dir, key string, r io.Reader) (string, int64, error) {
 	return path, n, nil
 }
 
-func writeFileValidate(c *Cache,
-	dir, key string, r io.Reader) (string, int64, error) {
-
-	path := realFilePath(dir, key)
-	tmpPath := path + ".tmp"
-
-	f, err := os.Create(tmpPath)
-	if err != nil {
-		return "", 0, &FileError{dir, key, err}
-	}
-
-	var total int64
-	exoBuf := s3FsPool.Get().(*exoBuffer)
-	defer s3FsPool.Put(exoBuf)
-
-	for {
-		// validate
-		c.l.Lock()
-		if err := c.validate(tmpPath, int64(chunkSize)); err != nil {
-			c.l.Unlock()
-			return tmpPath, 0, err
-		}
-		c.l.Unlock()
-
-		// copy
-		n, errRead := r.Read(exoBuf.bytes)
-		if n == 0 && errRead == io.EOF {
-			break
-		} else if n == 0 && errRead != nil {
-			_ = f.Close()
-			return tmpPath, 0, &FileError{dir, key, err}
-		}
-
-		w, err := f.WriteAt(exoBuf.bytes[0:n], total)
-		if err != nil {
-			_ = f.Close()
-			return tmpPath, 0, &FileError{dir, key, err}
-		}
-
-		total += int64(w)
-	}
-
-	err = f.Close()
-	if err != nil {
-		return tmpPath, total, &FileError{dir, key, err}
-	}
-
-	err = os.Rename(tmpPath, path)
-	if err != nil {
-		return tmpPath, total, &FileError{dir, key, err}
-	}
-
-	return path, total, nil
-}
-
 func shasum(v string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(v)))
 }
 
 func realFilePath(dir, key string) string {
 	name := shasum(key) + ".cache"
+	//name := key + ".cache"
 	return path.Join(dir, name)
 }

--- a/file.go
+++ b/file.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path"
 	"sync"
+
+	"github.com/gofrs/uuid"
 )
 
 type exoBuffer struct {
@@ -22,10 +24,18 @@ var s3FsPool = sync.Pool{
 }
 
 // writeFile writes a new file to the cache storage.
-func writeFile(dir, key string, r io.Reader) (string, int64, error) {
-	path := realFilePath(dir, key)
+func writeTmpFile(dir, key string, r io.Reader) (string, int64, error) {
+
+	ukey, err := uuid.NewV4()
+	if err != nil {
+		return "", 0, &FileError{dir, key, err}
+	}
+
+	path := path.Join(dir, ukey.String())
+
 	f, err := os.Create(path)
 	defer f.Close()
+
 	if err != nil {
 		return "", 0, &FileError{dir, key, err}
 	}

--- a/stash.go
+++ b/stash.go
@@ -37,7 +37,8 @@ type Cache struct {
 
 // New creates a Cache backed by dir on disk. The cache allows at most c files of total size sz.
 func New(dir string, sz, c int64) (*Cache, error) {
-	if !validDir(dir) {
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil, ErrBadDir
 	}
 	if sz <= 0 {
@@ -434,9 +435,4 @@ func (c *Cache) addMeta(key string, tag []byte, path string, length int64) {
 	}
 	listElement := c.list.PushFront(item)
 	c.m[key] = listElement
-}
-
-func validDir(dir string) bool {
-	// XXX(hjr265): We need to ensure the disk is either empty, or contains a valid cache storage.
-	return dir != ""
 }

--- a/stash.go
+++ b/stash.go
@@ -67,7 +67,23 @@ func (c *Cache) PutReader(key string, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if err := c.validate(path, n); err != nil { // XXX(hjr265): We should validate before storing the file.
+	if err := c.validate(path, n); err != nil {
+		return err
+	}
+	c.addMeta(key, path, n)
+	return nil
+}
+
+// PutReaderChunked adds the contents of a reader, validating size for single chunk
+func (c *Cache) PutReaderChunked(key string, r io.Reader) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	path, n, err := writeFileValidate(c, c.dir, key, r)
+	if err != nil {
+		return err
+	}
+	if err := c.validate(path, n); err != nil {
 		return err
 	}
 	c.addMeta(key, path, n)

--- a/stash.go
+++ b/stash.go
@@ -98,11 +98,11 @@ func (c *Cache) UnlockedClear() error {
 func (c *Cache) SetTag(key string, tag []byte) error {
 	c.l.Lock()
 	defer c.l.Unlock()
-	return c.SetTagUnlocked(key, tag)
+	return c.UnlockedSetTag(key, tag)
 }
 
-// SetTagUnlocked is the concurrency-unsafe version of SetTag.
-func (c *Cache) SetTagUnlocked(key string, tag []byte) error {
+// UnlockedSetTag is the concurrency-unsafe version of SetTag.
+func (c *Cache) UnlockedSetTag(key string, tag []byte) error {
 	if item, ok := c.m[key]; ok {
 		meta := item.Value.(*Meta)
 		switch {
@@ -122,11 +122,11 @@ func (c *Cache) SetTagUnlocked(key string, tag []byte) error {
 func (c *Cache) GetTag(key string) ([]byte, error) {
 	c.l.Lock()
 	defer c.l.Unlock()
-	return c.GetTagUnlocked(key)
+	return c.UnlockedGetTag(key)
 }
 
-// GetTagUnlocked is the concurrency-unsafe version of GetTag.
-func (c *Cache) GetTagUnlocked(key string) ([]byte, error) {
+// UnlockedGetTag is the concurrency-unsafe version of GetTag.
+func (c *Cache) UnlockedGetTag(key string) ([]byte, error) {
 	if item, ok := c.m[key]; ok {
 		return item.Value.(*Meta).Tag, nil
 	}

--- a/stash.go
+++ b/stash.go
@@ -24,6 +24,8 @@ type Cache struct {
 	maxCap  int64  // Total number of files allowed
 	size    int64  // Total size of files added
 	cap     int64  // Total number of files added
+	hit     int64  // Cache hit
+	miss    int64  // Cache miss...
 
 	list *list.List               // List of items in cache
 	m    map[string]*list.Element // Map of items in list
@@ -100,11 +102,30 @@ func (c *Cache) Get(key string) (io.ReadCloser, error) {
 		if f, err := os.Open(path); err != nil {
 			return nil, err
 		} else {
+			c.hit++
 			return f, nil
 		}
 	} else {
+		c.miss++
 		return nil, ErrNotFound
 	}
+}
+
+// Return Cache stats.
+func (c *Cache) Stats() (int64, int64, int64, int64) {
+	return c.size, c.cap, c.hit, c.miss
+}
+
+func (c *Cache) Empty() bool {
+	return c.cap == 0
+}
+
+func (c *Cache) Cap() int64 {
+	return c.cap
+}
+
+func (c *Cache) Size() int64 {
+	return c.size
 }
 
 // Keys returns a list of keys in the cache.

--- a/stash.go
+++ b/stash.go
@@ -415,11 +415,16 @@ func (c *Cache) evictLast() error {
 
 // addMeta adds meta information to the cache.
 func (c *Cache) addMeta(key string, tag []byte, path string, length int64) {
-	c.size += length
-	c.numEntries++
+	oldlength := int64(0)
+
 	if item, ok := c.m[key]; ok {
+		oldlength = item.Value.(*Meta).Size
 		c.list.Remove(item)
+	} else {
+		c.numEntries++
 	}
+
+	c.size += (length - oldlength)
 
 	item := &Meta{
 		Key:  key,

--- a/stash.go
+++ b/stash.go
@@ -92,8 +92,8 @@ func (c *Cache) PutReaderChunked(key string, r io.Reader) error {
 
 // Get returns a reader for a blob in the cache, or ErrNotFound otherwise.
 func (c *Cache) Get(key string) (io.ReadCloser, error) {
-	c.l.RLock()
-	defer c.l.RUnlock()
+	c.l.Lock()
+	defer c.l.Unlock()
 
 	if item, ok := c.m[key]; ok {
 		c.list.MoveToFront(item)

--- a/stash.go
+++ b/stash.go
@@ -28,7 +28,7 @@ type Cache struct {
 	list *list.List               // List of items in cache
 	m    map[string]*list.Element // Map of items in list
 
-	l sync.RWMutex
+	l sync.Mutex
 }
 
 // New creates a Cache backed by dir on disk. The cache allows at most c files of total size sz.

--- a/stash.go
+++ b/stash.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Meta is the information about the cache entry.
 type Meta struct {
 	Key  string
 	Size int64
@@ -62,14 +63,14 @@ func New(dir string, sz, c int64) (*Cache, error) {
 	return cache, nil
 }
 
-// Clear the cache, erase the cache files from the directory
-
+// Clear resets the cache and erases the files from the cache directory.
 func (c *Cache) Clear() error {
 	c.l.Lock()
 	defer c.l.Unlock()
 	return c.UnlockedClear()
 }
 
+// UnlockedClear is the concurrency unsafe version of Clear function.
 func (c *Cache) UnlockedClear() error {
 	c.size = 0
 	c.cap = 0
@@ -168,7 +169,7 @@ func (c *Cache) UnlockedPutReaderWithTag(key string, tag []byte, r io.Reader) er
 	return nil
 }
 
-// PutReaderChunked adds the contents of a reader, validating size for single chunk
+// PutReaderChunked adds the contents of a reader, validating size chunk.
 func (c *Cache) PutReaderChunked(key string, r io.Reader) error {
 	return c.LockablePutReaderChunkedWithTag(key, nil, r, &c.l)
 }
@@ -237,6 +238,8 @@ func (c *Cache) Delete(key string) error {
 	defer c.l.Unlock()
 	return c.UnlockedDelete(key)
 }
+
+// UnlockedDelete is the concurrency unsafe version of Delete.
 func (c *Cache) UnlockedDelete(key string) error {
 	elem, ok := c.m[key]
 	if !ok {
@@ -252,49 +255,63 @@ func (c *Cache) UnlockedDelete(key string) error {
 	return nil
 }
 
-// Cache stats...
+// Stats returns the Cache stats.
 func (c *Cache) Stats() (int64, int64, int64, int64) {
 	c.l.Lock()
 	defer c.l.Unlock()
 	return c.UnlockedStats()
 }
+
+// UnlockedStats is the concurrency unsafe version of Stats.
 func (c *Cache) UnlockedStats() (int64, int64, int64, int64) {
 	return c.size, c.cap, c.hit, c.miss
 }
 
+// ResetStats resets the statistics of the cache.
 func (c *Cache) ResetStats() {
 	c.l.Lock()
 	defer c.l.Unlock()
 	c.UnlockedResetStats()
 }
+
+// UnlockedResetStats is the concurrency unsafe version of ResetStats.
 func (c *Cache) UnlockedResetStats() {
 	c.hit = 0
 	c.miss = 0
 }
 
+// Empty returns true if the cache is empty.
 func (c *Cache) Empty() bool {
 	c.l.Lock()
 	defer c.l.Unlock()
 	return c.UnlockedEmpty()
 }
+
+// UnlockedEmpty is true if the cache is the concurrency unsafe version of Empty.
 func (c *Cache) UnlockedEmpty() bool {
 	return c.cap == 0
 }
 
+// Cap returns the current capacity of the cache.
 func (c *Cache) Cap() int64 {
 	c.l.Lock()
 	defer c.l.Unlock()
 	return c.UnlockedCap()
 }
+
+// UnlockedCap is the concurrency unsafe version of Cap.
 func (c *Cache) UnlockedCap() int64 {
 	return c.cap
 }
 
+// Size returns the size of the cache.
 func (c *Cache) Size() int64 {
 	c.l.Lock()
 	defer c.l.Unlock()
 	return c.UnlockedSize()
 }
+
+// UnlockedSize is the concurrency unsafe version of Size.
 func (c *Cache) UnlockedSize() int64 {
 	return c.size
 }
@@ -305,6 +322,8 @@ func (c *Cache) Keys() []string {
 	defer c.l.Unlock()
 	return c.UnlockedKeys()
 }
+
+// UnlockedKeys is the concurrency unsafe version of Keys.
 func (c *Cache) UnlockedKeys() []string {
 	keys := make([]string, len(c.m))
 	i := 0
@@ -319,7 +338,6 @@ func (c *Cache) UnlockedKeys() []string {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // validate ensures the file satisfies the constraints of the cache.
-
 func (c *Cache) validate(path string, n int64) error {
 	if n > c.maxSize {
 		os.Remove(path) // XXX(hjr265): We should not suppress this error even if it is very unlikely.

--- a/stash.go
+++ b/stash.go
@@ -131,18 +131,26 @@ func (c *Cache) Delete(key string) error {
 
 // Return Cache stats.
 func (c *Cache) Stats() (int64, int64, int64, int64) {
+	c.l.Lock()
+	defer c.l.Unlock()
 	return c.size, c.cap, c.hit, c.miss
 }
 
 func (c *Cache) Empty() bool {
+	c.l.Lock()
+	defer c.l.Unlock()
 	return c.cap == 0
 }
 
 func (c *Cache) Cap() int64 {
+	c.l.Lock()
+	defer c.l.Unlock()
 	return c.cap
 }
 
 func (c *Cache) Size() int64 {
+	c.l.Lock()
+	defer c.l.Unlock()
 	return c.size
 }
 

--- a/stash.go
+++ b/stash.go
@@ -12,6 +12,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Stats is the cache stats.
+type Stats struct {
+	Size    int64
+	Entries int64
+	Hit     int64
+	Miss    int64
+}
+
 // Meta is the information about the cache entry.
 type Meta struct {
 	Key  string
@@ -244,11 +252,16 @@ func (c *Cache) Delete(key string) error {
 	return nil
 }
 
-// Stats returns the Cache stats.
-func (c *Cache) Stats() (int64, int64, int64, int64) {
+// GetStats returns the Cache stats.
+func (c *Cache) GetStats() Stats {
 	c.l.Lock()
 	defer c.l.Unlock()
-	return c.size, c.numEntries, c.hit, c.miss
+	return Stats{
+		Size:    c.size,
+		Entries: c.numEntries,
+		Hit:     c.hit,
+		Miss:    c.miss,
+	}
 }
 
 // ResetStats resets the statistics of the cache.

--- a/stash.go
+++ b/stash.go
@@ -111,6 +111,24 @@ func (c *Cache) Get(key string) (io.ReadCloser, error) {
 	}
 }
 
+// Delete a key from the cache, return error in case of key not present.
+func (c *Cache) Delete(key string) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	elem, ok := c.m[key]
+	if !ok {
+		return ErrNotFound
+	}
+
+	item := elem.Value.(*Meta)
+	c.size -= item.Size
+	c.cap--
+	delete(c.m, item.Key)
+	c.list.Remove(elem)
+	return nil
+}
+
 // Return Cache stats.
 func (c *Cache) Stats() (int64, int64, int64, int64) {
 	return c.size, c.cap, c.hit, c.miss

--- a/stash.go
+++ b/stash.go
@@ -105,8 +105,11 @@ func (c *Cache) SetTag(key string, tag []byte) error {
 func (c *Cache) SetTagUnlocked(key string, tag []byte) error {
 	if item, ok := c.m[key]; ok {
 		meta := item.Value.(*Meta)
-		if meta.Tag == nil {
+		switch {
+		case meta.Tag == nil:
 			item.Value.(*Meta).Tag = tag
+			return nil
+		case bytes.Equal(meta.Tag, tag):
 			return nil
 		}
 

--- a/stash.go
+++ b/stash.go
@@ -78,15 +78,14 @@ func (c *Cache) PutReader(key string, r io.Reader) error {
 
 // PutReaderChunked adds the contents of a reader, validating size for single chunk
 func (c *Cache) PutReaderChunked(key string, r io.Reader) error {
-	c.l.Lock()
-	defer c.l.Unlock()
-
 	path, n, err := writeFileValidate(c, c.dir, key, r)
 	if err != nil {
 		return errors.WithStack(os.Remove(path))
 	}
 
+	c.l.Lock()
 	c.addMeta(key, path, n)
+	c.l.Unlock()
 	return nil
 }
 

--- a/stash.go
+++ b/stash.go
@@ -56,6 +56,12 @@ func New(dir string, sz, c int64) (*Cache, error) {
 
 // Put adds a byte slice as a blob to the cache against the given key.
 func (c *Cache) Put(key string, val []byte) error {
+	if float64(c.sizeUsed * 100) / float64(c.size) > 90 {
+		err := c.evictLast()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
 	return c.PutReader(key, bytes.NewReader(val))
 }
 

--- a/stash.go
+++ b/stash.go
@@ -86,7 +86,9 @@ func (c *Cache) Clear() error {
 	names, err := d.Readdirnames(-1)
 	if err == nil {
 		for _, name := range names {
-			os.RemoveAll(filepath.Join(c.dir, name))
+			if filepath.Ext(name) == ".cache" {
+				os.RemoveAll(filepath.Join(c.dir, name))
+			}
 		}
 	}
 

--- a/stash.go
+++ b/stash.go
@@ -242,17 +242,17 @@ func (c *Cache) UnlockedGetWithTag(key string) (io.ReadCloser, []byte, error) {
 }
 
 // Delete a key from the cache if the given lambda returns true, do nothing otherwise.
-func (c *Cache) DeleteIf(key string, testTag func(tag []byte) bool) error {
+func (c *Cache) DeleteIf(key string, testTag func(tag []byte) bool) (bool, error) {
 	c.l.Lock()
 	defer c.l.Unlock()
 	return c.UnlockedDeleteIf(key, testTag)
 }
 
 // UnlockedDeleteIf is the concurrency-unsafe version of DeleteIf.
-func (c *Cache) UnlockedDeleteIf(key string, removeTest func(tag []byte) bool) error {
+func (c *Cache) UnlockedDeleteIf(key string, removeTest func(tag []byte) bool) (bool, error) {
 	elem, ok := c.m[key]
 	if !ok {
-		return ErrNotFound
+		return false, ErrNotFound
 	}
 	if item := elem.Value.(*Meta); removeTest(item.Tag) {
 		c.size -= item.Size
@@ -260,8 +260,10 @@ func (c *Cache) UnlockedDeleteIf(key string, removeTest func(tag []byte) bool) e
 		os.Remove(item.Path)
 		delete(c.m, item.Key)
 		c.list.Remove(elem)
+		return true, nil
 	}
-	return nil
+
+	return false, nil
 }
 
 // Delete a key from the cache, return error in case of key not present.

--- a/stash.go
+++ b/stash.go
@@ -56,12 +56,6 @@ func New(dir string, sz, c int64) (*Cache, error) {
 
 // Put adds a byte slice as a blob to the cache against the given key.
 func (c *Cache) Put(key string, val []byte) error {
-	if float64(c.sizeUsed * 100) / float64(c.size) > 90 {
-		err := c.evictLast()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
 	return c.PutReader(key, bytes.NewReader(val))
 }
 

--- a/stash.go
+++ b/stash.go
@@ -104,8 +104,13 @@ func (c *Cache) SetTag(key string, tag []byte) error {
 // SetTagUnlocked is the concurrency-unsafe version of SetTag.
 func (c *Cache) SetTagUnlocked(key string, tag []byte) error {
 	if item, ok := c.m[key]; ok {
-		item.Value.(*Meta).Tag = tag
-		return nil
+		meta := item.Value.(*Meta)
+		if meta.Tag == nil {
+			item.Value.(*Meta).Tag = tag
+			return nil
+		}
+
+		return ErrAlreadyTagged
 	}
 	return ErrNotFound
 }

--- a/stash.go
+++ b/stash.go
@@ -12,6 +12,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+type ReadSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
 // Stats is the cache stats.
 type Stats struct {
 	Size    int64
@@ -190,13 +196,13 @@ func (c *Cache) PutReaderChunkedWithTag(key string, tag []byte, r io.Reader) err
 }
 
 // Get returns a reader for a blob in the cache, or ErrNotFound otherwise.
-func (c *Cache) Get(key string) (io.ReadCloser, int64, error) {
+func (c *Cache) Get(key string) (ReadSeekCloser, int64, error) {
 	r, _, s, e := c.GetWithTag(key)
 	return r, s, e
 }
 
 // GetWithTag returns a reader for a blob in the cache along with the associated tag, or ErrNotFound otherwise.
-func (c *Cache) GetWithTag(key string) (io.ReadCloser, []byte, int64, error) {
+func (c *Cache) GetWithTag(key string) (ReadSeekCloser, []byte, int64, error) {
 	c.l.Lock()
 	defer c.l.Unlock()
 	if item, ok := c.m[key]; ok {

--- a/stash.go
+++ b/stash.go
@@ -124,6 +124,7 @@ func (c *Cache) Delete(key string) error {
 	item := elem.Value.(*Meta)
 	c.size -= item.Size
 	c.cap--
+	os.Remove(item.Path)
 	delete(c.m, item.Key)
 	c.list.Remove(elem)
 	return nil

--- a/stash.go
+++ b/stash.go
@@ -3,6 +3,7 @@ package stash
 import (
 	"bytes"
 	"container/list"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -76,6 +77,26 @@ func New(dir string, sz, c int64) (*Cache, error) {
 		return nil, err
 	}
 	return cache, nil
+}
+
+// Dump the content on the cache for debugging.
+func (c *Cache) Dump() {
+	c.l.Lock()
+	defer c.l.Unlock()
+	fmt.Printf("Stash: -------\n")
+	fmt.Printf("   dir        : %s\n", c.dir)
+	fmt.Printf("   max size   : %d\n", c.maxSize)
+	fmt.Printf("   max entries: %d\n", c.maxEntries)
+	fmt.Printf("   size       : %d\n", c.size)
+	fmt.Printf("   entries    : %d\n", c.numEntries)
+	fmt.Printf("   hit        : %d\n", c.hit)
+	fmt.Printf("   miss       : %d\n", c.miss)
+
+	for k, v := range c.m {
+		fmt.Printf("   key        : %s -> %+v\n", k, v.Value.(*Meta))
+	}
+
+	fmt.Printf("--------------\n")
 }
 
 // Clear resets the cache and erases the files from the cache directory.

--- a/stash.go
+++ b/stash.go
@@ -5,8 +5,8 @@ import (
 	"container/list"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -45,7 +45,7 @@ func New(dir string, sz, c int64) (*Cache, error) {
 		return nil, ErrBadCap
 	}
 
-	dir = strings.TrimRight(dir, string(os.PathSeparator)) // Clean path to dir
+	dir = filepath.Clean(dir)
 
 	return &Cache{
 		dir:     dir,
@@ -227,6 +227,5 @@ func (c *Cache) addMeta(key, path string, length int64) {
 
 func validDir(dir string) bool {
 	// XXX(hjr265): We need to ensure the disk is either empty, or contains a valid cache storage.
-
 	return dir != ""
 }

--- a/stash.go
+++ b/stash.go
@@ -151,7 +151,7 @@ func (c *Cache) UnlockedDelete(key string) error {
 	return nil
 }
 
-// Return Cache stats.
+// Cache stats...
 func (c *Cache) Stats() (int64, int64, int64, int64) {
 	c.l.Lock()
 	defer c.l.Unlock()
@@ -159,6 +159,16 @@ func (c *Cache) Stats() (int64, int64, int64, int64) {
 }
 func (c *Cache) UnlockedStats() (int64, int64, int64, int64) {
 	return c.size, c.cap, c.hit, c.miss
+}
+
+func (c *Cache) ResetStats() {
+	c.l.Lock()
+	defer c.l.Unlock()
+	c.UnlockedResetStats()
+}
+func (c *Cache) UnlockedResetStats() {
+	c.hit = 0
+	c.miss = 0
 }
 
 func (c *Cache) Empty() bool {

--- a/stash.go
+++ b/stash.go
@@ -70,7 +70,7 @@ func (c *Cache) Clear() error {
 	return c.UnlockedClear()
 }
 
-// UnlockedClear is the concurrency unsafe version of Clear function.
+// UnlockedClear is the concurrency-unsafe version of Clear function.
 func (c *Cache) UnlockedClear() error {
 	c.size = 0
 	c.cap = 0
@@ -101,7 +101,7 @@ func (c *Cache) SetTag(key string, tag []byte) error {
 	return c.SetTagUnlocked(key, tag)
 }
 
-// SetTagUnlocked is the concurrency unsafe version of SetTag.
+// SetTagUnlocked is the concurrency-unsafe version of SetTag.
 func (c *Cache) SetTagUnlocked(key string, tag []byte) error {
 	if item, ok := c.m[key]; ok {
 		item.Value.(*Meta).Tag = tag
@@ -117,7 +117,7 @@ func (c *Cache) GetTag(key string) ([]byte, error) {
 	return c.GetTagUnlocked(key)
 }
 
-// GetTagUnlocked is the concurrency unsafe version of GetTag.
+// GetTagUnlocked is the concurrency-unsafe version of GetTag.
 func (c *Cache) GetTagUnlocked(key string) ([]byte, error) {
 	if item, ok := c.m[key]; ok {
 		return item.Value.(*Meta).Tag, nil
@@ -135,7 +135,7 @@ func (c *Cache) PutWithTag(key string, tag, val []byte) error {
 	return c.PutReaderWithTag(key, tag, bytes.NewReader(val))
 }
 
-// UnlockedPutWithTag is the concurrency unsafe version of PutWithTag.
+// UnlockedPutWithTag is the concurrency-unsafe version of PutWithTag.
 func (c *Cache) UnlockedPutWithTag(key string, tag, val []byte) error {
 	return c.UnlockedPutReaderWithTag(key, tag, bytes.NewReader(val))
 }
@@ -154,7 +154,7 @@ func (c *Cache) PutReaderWithTag(key string, tag []byte, r io.Reader) error {
 	return c.UnlockedPutReaderWithTag(key, tag, r)
 }
 
-// UnlockedPutReaderWithTag is the concurrency unsafe version of PutReaderWithTag.
+// UnlockedPutReaderWithTag is the concurrency-unsafe version of PutReaderWithTag.
 func (c *Cache) UnlockedPutReaderWithTag(key string, tag []byte, r io.Reader) error {
 
 	path, n, err := writeFile(c.dir, key, r)
@@ -179,12 +179,13 @@ func (c *Cache) PutReaderChunkedWithTag(key string, tag []byte, r io.Reader) err
 	return c.LockablePutReaderChunkedWithTag(key, tag, r, &c.l)
 }
 
-// UnlockedPutReaderChunkedWithTag is the concurrency unsafe version of PutReaderChunkedWithTag.
+// UnlockedPutReaderChunkedWithTag is the concurrency-unsafe version of PutReaderChunkedWithTag.
 func (c *Cache) UnlockedPutReaderChunkedWithTag(key string, tag []byte, r io.Reader) error {
 	return c.LockablePutReaderChunkedWithTag(key, tag, r, nil)
 }
 
-// LockablePutReaderChunkedWithTag, like PutReaderChunkedWithTag, only with an extra optional mutex to lock.
+// LockablePutReaderChunkedWithTag, like PutReaderChunkedWithTag, only with an extra optional pointer to mutex to lock.
+// If nil is passed, this version is concurrency-unsafe.
 func (c *Cache) LockablePutReaderChunkedWithTag(key string, tag []byte, r io.Reader, m *sync.Mutex) error {
 	path, n, err := writeFileValidate(c, c.dir, key, r)
 	if err != nil {
@@ -215,7 +216,7 @@ func (c *Cache) GetWithTag(key string) (io.ReadCloser, []byte, error) {
 	return c.UnlockedGetWithTag(key)
 }
 
-// UnlockedGetWithTag is the concurrency unsafe version of GetWithTag.
+// UnlockedGetWithTag is the concurrency-unsafe version of GetWithTag.
 func (c *Cache) UnlockedGetWithTag(key string) (io.ReadCloser, []byte, error) {
 	if item, ok := c.m[key]; ok {
 		c.list.MoveToFront(item)
@@ -239,7 +240,7 @@ func (c *Cache) Delete(key string) error {
 	return c.UnlockedDelete(key)
 }
 
-// UnlockedDelete is the concurrency unsafe version of Delete.
+// UnlockedDelete is the concurrency-unsafe version of Delete.
 func (c *Cache) UnlockedDelete(key string) error {
 	elem, ok := c.m[key]
 	if !ok {
@@ -262,7 +263,7 @@ func (c *Cache) Stats() (int64, int64, int64, int64) {
 	return c.UnlockedStats()
 }
 
-// UnlockedStats is the concurrency unsafe version of Stats.
+// UnlockedStats is the concurrency-unsafe version of Stats.
 func (c *Cache) UnlockedStats() (int64, int64, int64, int64) {
 	return c.size, c.cap, c.hit, c.miss
 }
@@ -274,7 +275,7 @@ func (c *Cache) ResetStats() {
 	c.UnlockedResetStats()
 }
 
-// UnlockedResetStats is the concurrency unsafe version of ResetStats.
+// UnlockedResetStats is the concurrency-unsafe version of ResetStats.
 func (c *Cache) UnlockedResetStats() {
 	c.hit = 0
 	c.miss = 0
@@ -287,7 +288,7 @@ func (c *Cache) Empty() bool {
 	return c.UnlockedEmpty()
 }
 
-// UnlockedEmpty is true if the cache is the concurrency unsafe version of Empty.
+// UnlockedEmpty is true if the cache is the concurrency-unsafe version of Empty.
 func (c *Cache) UnlockedEmpty() bool {
 	return c.cap == 0
 }
@@ -299,7 +300,7 @@ func (c *Cache) Cap() int64 {
 	return c.UnlockedCap()
 }
 
-// UnlockedCap is the concurrency unsafe version of Cap.
+// UnlockedCap is the concurrency-unsafe version of Cap.
 func (c *Cache) UnlockedCap() int64 {
 	return c.cap
 }
@@ -311,7 +312,7 @@ func (c *Cache) Size() int64 {
 	return c.UnlockedSize()
 }
 
-// UnlockedSize is the concurrency unsafe version of Size.
+// UnlockedSize is the concurrency-unsafe version of Size.
 func (c *Cache) UnlockedSize() int64 {
 	return c.size
 }
@@ -323,7 +324,7 @@ func (c *Cache) Keys() []string {
 	return c.UnlockedKeys()
 }
 
-// UnlockedKeys is the concurrency unsafe version of Keys.
+// UnlockedKeys is the concurrency-unsafe version of Keys.
 func (c *Cache) UnlockedKeys() []string {
 	keys := make([]string, len(c.m))
 	i := 0

--- a/stash.go
+++ b/stash.go
@@ -72,7 +72,7 @@ type Cache struct {
 }
 
 // New creates a Cache backed by dir on disk. The cache allows at most c files of total size sz.
-func New(dir string, sz, c int64) (*Cache, error) {
+func NewCache(dir string, sz, c int64) (*Cache, error) {
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil, ErrBadDir

--- a/stash_test.go
+++ b/stash_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"reflect"
 	"testing"
 )
@@ -112,7 +111,7 @@ func TestCachePut(t *testing.T) {
 	}
 
 	for k, b := range blobs {
-		path := path.Join(storageDir, shasum(k))
+		path := realFilePath(storageDir, k)
 		v, err := ioutil.ReadFile(path)
 		catch(err)
 		if !bytes.Equal(b, v) {

--- a/stash_test.go
+++ b/stash_test.go
@@ -121,6 +121,19 @@ func TestCachePut(t *testing.T) {
 	}
 }
 
+func TestAlreadyTagged(t *testing.T) {
+	clearStorage()
+
+	s, err := New(storageDir, 2048000, 40)
+	catch(err)
+	err = s.PutWithTag("test", []byte("test"), []byte("content"))
+	catch(err)
+	err = s.SetTag("test", []byte("test2"))
+	if err != ErrAlreadyTagged {
+		t.Fatalf("Expected error == ErrAlreadyTagged, got error '%s'", err)
+	}
+}
+
 func TestCachePutAndGetWithTag(t *testing.T) {
 	clearStorage()
 

--- a/stash_test.go
+++ b/stash_test.go
@@ -135,12 +135,12 @@ func TestDeleteIf(t *testing.T) {
 		t.Fatalf("Expected size == 2, got %d", sz)
 	}
 
-	err = s.DeleteIf("test1", func(tag []byte) bool {
+	_, err = s.DeleteIf("test1", func(tag []byte) bool {
 		return bytes.Equal(tag, []byte("tag1"))
 	})
 	catch(err)
 
-	err = s.DeleteIf("test2", func(tag []byte) bool {
+	_, err = s.DeleteIf("test2", func(tag []byte) bool {
 		return bytes.Equal(tag, []byte("tag1"))
 	})
 	catch(err)

--- a/stash_test.go
+++ b/stash_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"reflect"
 	"testing"
 )
@@ -70,7 +71,7 @@ func TestCachePut(t *testing.T) {
 	}
 
 	for k, b := range blobs {
-		path := filepath(storageDir, shasum(k))
+		path := path.Join(storageDir, shasum(k))
 		v, err := ioutil.ReadFile(path)
 		catch(err)
 		if !bytes.Equal(b, v) {

--- a/stash_test.go
+++ b/stash_test.go
@@ -173,7 +173,7 @@ func TestCachePutAndGetWithTag(t *testing.T) {
 	}
 
 	for k, _ := range blobs {
-		_, tag, err := s.GetWithTag(k)
+		_, tag, _, err := s.GetWithTag(k)
 		catch(err)
 		if !bytes.Equal([]byte(k), tag) {
 			t.Fatalf("Expected tag == %q, got %q", k, tag)
@@ -210,27 +210,27 @@ func TestCacheDeleteAndStats(t *testing.T) { // cache
 		catch(err)
 	}
 
-	if _, err := s.Get("missing"); err == nil {
+	if _, _, err := s.Get("missing"); err == nil {
 		t.Fatalf("Miss Expected!")
 	}
-	_, c, h, m := s.Stats()
-	if c != int64(len(blobs)) {
-		t.Fatalf("Expected cap == %v, got %v", len(blobs), c)
+	stats := s.GetStats()
+	if stats.Entries != int64(len(blobs)) {
+		t.Fatalf("Expected entries == %v, got %v", len(blobs), stats.Entries)
 	}
 
-	if h != 0 {
-		t.Fatalf("Expected hit == 0, got %v", m)
+	if stats.Hit != 0 {
+		t.Fatalf("Expected hit == 0, got %v", stats.Hit)
 	}
 
 	s.Get("gopher")
 	s.Get("gopher")
 
-	if _, _, h, _ := s.Stats(); h != 2 {
-		t.Fatalf("Expected hit == 2, got %v", h)
+	if stats := s.GetStats(); stats.Hit != 2 {
+		t.Fatalf("Expected hit == 2, got %v", stats.Hit)
 	}
 
-	if m != 1 {
-		t.Fatalf("Expected miss == 1, got %v", m)
+	if stats.Miss != 1 {
+		t.Fatalf("Expected miss == 1, got %v", stats.Miss)
 	}
 
 	for k, _ := range blobs {

--- a/stash_test.go
+++ b/stash_test.go
@@ -121,6 +121,35 @@ func TestCachePut(t *testing.T) {
 	}
 }
 
+func TestDeleteIf(t *testing.T) {
+	clearStorage()
+
+	s, err := New(storageDir, 2048000, 40)
+	catch(err)
+	err = s.PutWithTag("test1", []byte("tag1"), []byte("content"))
+	catch(err)
+	err = s.PutWithTag("test2", []byte("tag2"), []byte("content"))
+	catch(err)
+
+	if sz := s.NumEntries(); sz != 2 {
+		t.Fatalf("Expected size == 2, got %d", sz)
+	}
+
+	err = s.DeleteIf("test1", func(tag []byte) bool {
+		return bytes.Equal(tag, []byte("tag1"))
+	})
+	catch(err)
+
+	err = s.DeleteIf("test2", func(tag []byte) bool {
+		return bytes.Equal(tag, []byte("tag1"))
+	})
+	catch(err)
+
+	if sz := s.NumEntries(); sz != 1 {
+		t.Fatalf("Expected size == 1, got %d", sz)
+	}
+}
+
 func TestAlreadyTagged(t *testing.T) {
 	clearStorage()
 

--- a/stash_test.go
+++ b/stash_test.go
@@ -67,7 +67,7 @@ func TestNew(t *testing.T) {
 	} {
 		clearStorage()
 
-		_, err := New(c.dir, c.sz, c.c)
+		_, err := NewCache(c.dir, c.sz, c.c)
 		if err != c.err {
 			t.Fatalf("#%d: Expected err == %q, got %q", i+1, c.err, err)
 		}
@@ -76,7 +76,7 @@ func TestNew(t *testing.T) {
 
 func TestClear(t *testing.T) {
 	clearStorage()
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	for k, b := range blobs {
 		err := s.Put(k, b)
@@ -103,7 +103,7 @@ func TestClear(t *testing.T) {
 func TestCachePut(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	for k, b := range blobs {
 		err := s.Put(k, b)
@@ -123,7 +123,7 @@ func TestCachePut(t *testing.T) {
 func TestDeleteIf(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	err = s.PutWithTag("test1", []byte("tag1"), []byte("content"))
 	catch(err)
@@ -152,7 +152,7 @@ func TestDeleteIf(t *testing.T) {
 func TestAlreadyTagged(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	err = s.PutWithTag("test", []byte("test"), []byte("content"))
 	catch(err)
@@ -165,7 +165,7 @@ func TestAlreadyTagged(t *testing.T) {
 func TestCachePutAndGetWithTag(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	for k, b := range blobs {
 		err := s.PutWithTag(k, []byte(k), b)
@@ -184,7 +184,7 @@ func TestCachePutAndGetWithTag(t *testing.T) {
 func TestCacheSetAndGetTag(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	for k, b := range blobs {
 		err := s.Put(k, b)
@@ -203,7 +203,7 @@ func TestCacheSetAndGetTag(t *testing.T) {
 func TestCacheDeleteAndStats(t *testing.T) { // cache
 	clearStorage()
 
-	s, err := New(storageDir, 2048000, 40)
+	s, err := NewCache(storageDir, 2048000, 40)
 	catch(err)
 	for k, b := range blobs {
 		err := s.Put(k, b)
@@ -254,7 +254,7 @@ func TestCacheDeleteAndStats(t *testing.T) { // cache
 func TestSizeEviction(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 10, 40)
+	s, err := NewCache(storageDir, 10, 40)
 	catch(err)
 
 	err = s.Put("a", []byte("abcdefgh"))
@@ -283,7 +283,7 @@ func TestSizeEviction(t *testing.T) {
 func TestCapEviction(t *testing.T) {
 	clearStorage()
 
-	s, err := New(storageDir, 2048, 3)
+	s, err := NewCache(storageDir, 2048, 3)
 	catch(err)
 
 	err = s.Put("a", []byte("abcdefg"))

--- a/stash_test.go
+++ b/stash_test.go
@@ -83,7 +83,7 @@ func TestClear(t *testing.T) {
 		err := s.Put(k, b)
 		catch(err)
 	}
-	cl := s.Cap()
+	cl := s.NumEntries()
 	if cl != int64(len(blobs)) {
 		t.Fatalf("Expected cap == %d, got %d", len(blobs), cl)
 	}

--- a/stash_test.go
+++ b/stash_test.go
@@ -121,6 +121,44 @@ func TestCachePut(t *testing.T) {
 	}
 }
 
+func TestCachePutAndGetWithTag(t *testing.T) {
+	clearStorage()
+
+	s, err := New(storageDir, 2048000, 40)
+	catch(err)
+	for k, b := range blobs {
+		err := s.PutWithTag(k, []byte(k), b)
+		catch(err)
+	}
+
+	for k, _ := range blobs {
+		_, tag, err := s.GetWithTag(k)
+		catch(err)
+		if !bytes.Equal([]byte(k), tag) {
+			t.Fatalf("Expected tag == %q, got %q", k, tag)
+		}
+	}
+}
+
+func TestCacheSetAndGetTag(t *testing.T) {
+	clearStorage()
+
+	s, err := New(storageDir, 2048000, 40)
+	catch(err)
+	for k, b := range blobs {
+		err := s.Put(k, b)
+		s.SetTag(k, []byte("tag"))
+		catch(err)
+	}
+
+	for k, _ := range blobs {
+		tag, _ := s.GetTag(k)
+		if !bytes.Equal(tag, []byte("tag")) {
+			t.Fatalf("Expected tag == \"tag\", got %q", tag)
+		}
+	}
+}
+
 func TestCacheDeleteAndStats(t *testing.T) { // cache
 	clearStorage()
 


### PR DESCRIPTION
This function permits to write and validate the cache in the same step.
In this way is possible to manage hundreds of parallel connections without exceeding the quota limit.